### PR TITLE
fix(deps): update sonarwhal to webhint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 
 # Sonarwhal
 /cdp.pid
-/sonarwhal.scan
+/webhint.scan
 
 # Site Build
 /Site_Build.tgz

--- a/.hintrc
+++ b/.hintrc
@@ -11,9 +11,9 @@
     ],
     "ignoredUrls": [{
       "domain": "https://www\\.google-analytics\\.com/.*",
-      "rules": ["*"]
+      "hints": ["*"]
     }],
-    "rules": {
+    "hints": {
         "amp-validator": "off",
         "apple-touch-icons": "warning",
         "axe": "warning",
@@ -45,5 +45,5 @@
         "validate-set-cookie-header": "warning",
         "x-content-type-options": "warning"
     },
-    "rulesTimeout": 120000
+    "hintsTimeout": 120000
 }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
   "bugs": {
     "url": "https://github.com/genpw/genpw.com/issues"
   },
-  "license": "MIT",
-  "author": "Matthew Miller <matthew@mi11er.net> (https://mi11er.net)",
-  "contributors": [],
   "repository": {
     "type": "git",
     "url": "https://github.com/genpw/genpw.com.git"
   },
+  "license": "MIT",
+  "author": "Matthew Miller <matthew@mi11er.net> (https://mi11er.net)",
+  "contributors": [],
   "scripts": {
     "prebuild": "run-p lint clean",
     "build": "per-env",
@@ -24,7 +24,7 @@
     "deploy": "per-env",
     "predeploy:production": "build",
     "deploy:production": "firebase deploy",
-    "postdeploy:production": "sonarwhal https://genpw.com >sonarwhal.scan",
+    "postdeploy:production": "hint https://genpw.com >webhint.scan",
     "lint": "eslint --fix .",
     "lint-staged": "lint-staged",
     "nsp": "nsp check",
@@ -77,6 +77,7 @@
     "eslint-plugin-scanjs-rules": "0.2.1",
     "eslint-plugin-security": "1.4.0",
     "firebase-tools": "3.19.3",
+    "hint": "^3.2.0",
     "husky": "0.14.3",
     "jstransformer-pug": "0.3.0",
     "lint-staged": "7.2.0",
@@ -98,7 +99,6 @@
     "queue": "4.4.2",
     "rimraf": "2.6.2",
     "semantic-release": "15.5.0",
-    "sonarwhal": "1.11.2",
     "sort-package-json": "1.15.0",
     "uglifyjs-webpack-plugin": "1.2.7",
     "webpack": "4.15.1",
@@ -119,7 +119,9 @@
       },
       {
         "path": "@semantic-release/git",
-        "assets": ["**"]
+        "assets": [
+          "**"
+        ]
       }
     ],
     "publish": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,6 +152,221 @@
     string-format-obj "^1.0.0"
     through2 "^2.0.0"
 
+"@hint/configuration-web-recommended@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@hint/configuration-web-recommended/-/configuration-web-recommended-1.1.0.tgz#f00211623e07c3b38e172bd6afd986d7f289c39e"
+  dependencies:
+    "@hint/connector-chrome" "^1.0.0"
+    "@hint/connector-jsdom" "^1.0.0"
+    "@hint/formatter-html" "^1.0.1"
+    "@hint/formatter-stylish" "^1.0.0"
+    "@hint/formatter-summary" "^1.0.0"
+    "@hint/hint-axe" "^1.0.1"
+    "@hint/hint-content-type" "^1.0.2"
+    "@hint/hint-disown-opener" "^1.0.1"
+    "@hint/hint-highest-available-document-mode" "^1.0.2"
+    "@hint/hint-html-checker" "^1.0.1"
+    "@hint/hint-http-cache" "^1.0.2"
+    "@hint/hint-http-compression" "^1.0.2"
+    "@hint/hint-image-optimization-cloudinary" "^1.0.2"
+    "@hint/hint-meta-charset-utf-8" "^1.0.1"
+    "@hint/hint-meta-viewport" "^1.0.1"
+    "@hint/hint-no-bom" "^1.0.1"
+    "@hint/hint-no-disallowed-headers" "^1.0.2"
+    "@hint/hint-no-friendly-error-pages" "^1.0.1"
+    "@hint/hint-no-html-only-headers" "^1.0.2"
+    "@hint/hint-no-http-redirects" "^1.0.2"
+    "@hint/hint-no-protocol-relative-urls" "^1.0.1"
+    "@hint/hint-no-vulnerable-javascript-libraries" "^1.0.0"
+    "@hint/hint-sri" "^1.0.1"
+    "@hint/hint-ssllabs" "^1.0.1"
+    "@hint/hint-strict-transport-security" "^1.0.2"
+    "@hint/hint-stylesheet-limits" "^1.0.0"
+    "@hint/hint-validate-set-cookie-header" "^1.0.1"
+    "@hint/hint-x-content-type-options" "^1.0.2"
+
+"@hint/connector-chrome@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hint/connector-chrome/-/connector-chrome-1.0.0.tgz#03a442b6e4f46e2dfff75ea46967d916636a893f"
+  dependencies:
+    "@hint/utils-debugging-protocol-common" "^1.0.0"
+    chrome-launcher "^0.10.2"
+    hint "^3.0.0"
+    is-ci "^1.1.0"
+    lockfile "^1.0.4"
+
+"@hint/connector-jsdom@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hint/connector-jsdom/-/connector-jsdom-1.0.0.tgz#d0f6c1b401677c239fe06e984641fb87dead9fd6"
+  dependencies:
+    "@hint/utils-connector-tools" "^1.0.0"
+    canvas-prebuilt "^1.6.5-prerelease.1"
+    hint "^3.0.0"
+    jsdom "^11.12.0"
+    node-pre-gyp "^0.10.3"
+
+"@hint/formatter-html@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/formatter-html/-/formatter-html-1.0.1.tgz#6e9bbe582273779077ca769b80af92161fc501dd"
+  dependencies:
+    ejs "^2.6.1"
+    fs-extra "^7.0.0"
+    lodash "^4.17.10"
+    moment "^2.22.2"
+
+"@hint/formatter-stylish@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hint/formatter-stylish/-/formatter-stylish-1.0.0.tgz#1d684faa1011a3d5feea120a35b3c1f830600b35"
+  dependencies:
+    chalk "^2.4.1"
+    lodash "^4.17.10"
+    log-symbols "^2.2.0"
+    text-table "^0.2.0"
+
+"@hint/formatter-summary@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hint/formatter-summary/-/formatter-summary-1.0.0.tgz#387c96cb129249be7786d99bc5a65722e557373b"
+  dependencies:
+    chalk "^2.4.1"
+    lodash "^4.17.10"
+    log-symbols "^2.2.0"
+    text-table "^0.2.0"
+
+"@hint/hint-axe@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/hint-axe/-/hint-axe-1.0.1.tgz#8700f8d0215ff13e87dd4a2753d8c58b9d1445c9"
+  dependencies:
+    axe-core "^3.0.2"
+
+"@hint/hint-content-type@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hint/hint-content-type/-/hint-content-type-1.0.2.tgz#ed3c5eed59ad11ed56c10214f72e6f82e2dff4de"
+  dependencies:
+    content-type "^1.0.4"
+
+"@hint/hint-disown-opener@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/hint-disown-opener/-/hint-disown-opener-1.0.1.tgz#8c08ff320d8947cd812c8c731d0fa559fb39c1b2"
+
+"@hint/hint-highest-available-document-mode@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hint/hint-highest-available-document-mode/-/hint-highest-available-document-mode-1.0.2.tgz#be86000ac15dbb89468d3cbc2e335b183f71dde4"
+
+"@hint/hint-html-checker@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/hint-html-checker/-/hint-html-checker-1.0.1.tgz#d981d517cd9d174b997403261c2ae7451eb76e92"
+  dependencies:
+    lodash "^4.17.10"
+
+"@hint/hint-http-cache@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hint/hint-http-cache/-/hint-http-cache-1.0.2.tgz#69a558376080ab628450d817e21428bf825f6aaf"
+
+"@hint/hint-http-compression@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hint/hint-http-compression/-/hint-http-compression-1.0.2.tgz#f6e89183c85635b1843bc9a78dd777d5209ce457"
+  dependencies:
+    brotli "^1.3.2"
+
+"@hint/hint-image-optimization-cloudinary@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hint/hint-image-optimization-cloudinary/-/hint-image-optimization-cloudinary-1.0.2.tgz#d5342a99282707b7924079ee27c10f5bd02cc847"
+  dependencies:
+    cloudinary "^1.9.1"
+    fs-extra "^7.0.0"
+    image-size "^0.6.3"
+
+"@hint/hint-meta-charset-utf-8@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/hint-meta-charset-utf-8/-/hint-meta-charset-utf-8-1.0.1.tgz#70e38631c442bac34ec8252bb8a98e4371cb1f53"
+  dependencies:
+    cheerio "^1.0.0-rc.2"
+
+"@hint/hint-meta-viewport@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/hint-meta-viewport/-/hint-meta-viewport-1.0.1.tgz#77c0134a7fc5b7dedc170397e1bb490da4c5d361"
+  dependencies:
+    metaviewport-parser "^0.2.0"
+
+"@hint/hint-no-bom@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/hint-no-bom/-/hint-no-bom-1.0.1.tgz#0634289c048b4831953c00cbf9e253ef7a522847"
+
+"@hint/hint-no-disallowed-headers@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hint/hint-no-disallowed-headers/-/hint-no-disallowed-headers-1.0.2.tgz#c06fa4484cce1eca6344ca75c433445e828a401e"
+
+"@hint/hint-no-friendly-error-pages@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/hint-no-friendly-error-pages/-/hint-no-friendly-error-pages-1.0.1.tgz#92024b612367e4e2b50e4efa1d28c9160a165ae5"
+
+"@hint/hint-no-html-only-headers@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hint/hint-no-html-only-headers/-/hint-no-html-only-headers-1.0.2.tgz#a436719cb43163de5c60f3dd41ca7ef0359a558b"
+
+"@hint/hint-no-http-redirects@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hint/hint-no-http-redirects/-/hint-no-http-redirects-1.0.2.tgz#1cab61f7c5e459375f1c3e9ae2e6868349084528"
+
+"@hint/hint-no-protocol-relative-urls@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/hint-no-protocol-relative-urls/-/hint-no-protocol-relative-urls-1.0.1.tgz#095298e35eca3b8fd818bb2e117a2f95ed6c14da"
+
+"@hint/hint-no-vulnerable-javascript-libraries@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hint/hint-no-vulnerable-javascript-libraries/-/hint-no-vulnerable-javascript-libraries-1.0.0.tgz#c875ade4a8e1c8fd8cfe6cbe5c36d821db611bf4"
+  dependencies:
+    js-library-detector "^5.0.0"
+    lodash "^4.17.10"
+    semver "^5.5.0"
+
+"@hint/hint-sri@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/hint-sri/-/hint-sri-1.0.1.tgz#f9d2a4d2e6256d75b579a6d3b23f074655611a2e"
+  dependencies:
+    async "^2.6.1"
+
+"@hint/hint-ssllabs@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/hint-ssllabs/-/hint-ssllabs-1.0.1.tgz#38f26db53274402c182b2f6c92313c97e8250181"
+  dependencies:
+    node-ssllabs "^0.5.0"
+
+"@hint/hint-strict-transport-security@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hint/hint-strict-transport-security/-/hint-strict-transport-security-1.0.2.tgz#13e2d73665986079a5210104725888fdb7e0f424"
+
+"@hint/hint-stylesheet-limits@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hint/hint-stylesheet-limits/-/hint-stylesheet-limits-1.0.0.tgz#1c12c369c7ad62bd922f60cdf8bf507cba24c553"
+
+"@hint/hint-validate-set-cookie-header@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hint/hint-validate-set-cookie-header/-/hint-validate-set-cookie-header-1.0.1.tgz#adae2efdde160659375315359ee6d714839b19b9"
+
+"@hint/hint-x-content-type-options@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hint/hint-x-content-type-options/-/hint-x-content-type-options-1.0.2.tgz#254ee900942c379c88bce8868ab6f7b7476c7dac"
+
+"@hint/utils-connector-tools@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hint/utils-connector-tools/-/utils-connector-tools-1.0.0.tgz#be00519f3cc4b0271cd908cca68f51f1542e9d54"
+  dependencies:
+    async "^2.6.1"
+    hint "^3.0.0"
+    iconv-lite "^0.4.23"
+    iltorb "^2.3.2"
+    request "^2.87.0"
+
+"@hint/utils-debugging-protocol-common@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hint/utils-debugging-protocol-common/-/utils-debugging-protocol-common-1.0.0.tgz#5eefd72fd61acf797efda3e740b90845f0b992db"
+  dependencies:
+    "@hint/utils-connector-tools" "^1.0.0"
+    chrome-remote-interface "^0.26.1"
+    hint "^3.0.0"
+    lodash "^4.17.10"
+
 "@mi11er/eslint-config@2.2.2":
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/@mi11er/eslint-config/-/eslint-config-2.2.2.tgz#847b4043fc5c7a3761d4b6e7cda79782c7892ae4"
@@ -290,194 +505,6 @@
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
-
-"@sonarwhal/configuration-web-recommended@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/configuration-web-recommended/-/configuration-web-recommended-6.1.0.tgz#2cf2d91561f3831171617792cc1346aabf087a1a"
-  dependencies:
-    "@sonarwhal/formatter-codeframe" "^2.0.3"
-    "@sonarwhal/formatter-stylish" "^2.0.4"
-    "@sonarwhal/formatter-summary" "^2.0.3"
-    "@sonarwhal/rule-axe" "^4.0.2"
-    "@sonarwhal/rule-content-type" "^3.0.4"
-    "@sonarwhal/rule-disown-opener" "^3.0.5"
-    "@sonarwhal/rule-highest-available-document-mode" "^3.0.4"
-    "@sonarwhal/rule-html-checker" "^4.0.0"
-    "@sonarwhal/rule-http-cache" "^3.1.2"
-    "@sonarwhal/rule-http-compression" "^4.0.2"
-    "@sonarwhal/rule-image-optimization-cloudinary" "^3.0.2"
-    "@sonarwhal/rule-meta-charset-utf-8" "^3.0.3"
-    "@sonarwhal/rule-meta-viewport" "^3.0.2"
-    "@sonarwhal/rule-no-bom" "^2.0.5"
-    "@sonarwhal/rule-no-disallowed-headers" "^3.0.4"
-    "@sonarwhal/rule-no-friendly-error-pages" "^3.0.2"
-    "@sonarwhal/rule-no-html-only-headers" "^3.0.5"
-    "@sonarwhal/rule-no-http-redirects" "^3.0.3"
-    "@sonarwhal/rule-no-protocol-relative-urls" "^3.0.2"
-    "@sonarwhal/rule-no-vulnerable-javascript-libraries" "^3.3.0"
-    "@sonarwhal/rule-sri" "^1.0.6"
-    "@sonarwhal/rule-ssllabs" "^3.0.3"
-    "@sonarwhal/rule-strict-transport-security" "^3.0.2"
-    "@sonarwhal/rule-stylesheet-limits" "^1.0.0"
-    "@sonarwhal/rule-validate-set-cookie-header" "^3.0.2"
-    "@sonarwhal/rule-x-content-type-options" "^3.0.3"
-
-"@sonarwhal/connector-edge@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/connector-edge/-/connector-edge-1.0.0.tgz#7e901a5d22e6a7ec59945796df7bcf22b27dc1ff"
-  dependencies:
-    edge-diagnostics-adapter "^0.6.0"
-    node-windows "^0.1.14"
-
-"@sonarwhal/formatter-codeframe@^2.0.3":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/formatter-codeframe/-/formatter-codeframe-2.0.4.tgz#c7ff2f7e65e32b949e336fc53ffb3e8a3bfa751f"
-  dependencies:
-    chalk "^2.4.1"
-    lodash.foreach "^4.5.0"
-    lodash.groupby "^4.6.0"
-    lodash.sortby "^4.7.0"
-    log-symbols "^2.2.0"
-
-"@sonarwhal/formatter-stylish@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/formatter-stylish/-/formatter-stylish-2.0.4.tgz#31b7a5c2506619d66c2bd7ed18c54a3ed7036251"
-  dependencies:
-    chalk "^2.4.1"
-    lodash.foreach "^4.5.0"
-    lodash.groupby "^4.6.0"
-    lodash.sortby "^4.7.0"
-    log-symbols "^2.2.0"
-    text-table "^0.2.0"
-
-"@sonarwhal/formatter-summary@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/formatter-summary/-/formatter-summary-2.0.3.tgz#80812907463241b7edabb55e4bde1dea4b530de9"
-  dependencies:
-    chalk "^2.4.1"
-    lodash.defaultto "^4.14.0"
-    lodash.foreach "^4.5.0"
-    lodash.groupby "^4.6.0"
-    log-symbols "^2.2.0"
-    text-table "^0.2.0"
-
-"@sonarwhal/rule-axe@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-axe/-/rule-axe-4.0.2.tgz#d4c7313fa2d39e063018011788e92fdbfe4412c9"
-  dependencies:
-    axe-core "^3.0.2"
-
-"@sonarwhal/rule-content-type@^3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-content-type/-/rule-content-type-3.0.4.tgz#711d570ca8424395a8d03554c94b09b1227733bc"
-  dependencies:
-    content-type "^1.0.4"
-
-"@sonarwhal/rule-disown-opener@^3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-disown-opener/-/rule-disown-opener-3.0.5.tgz#affe50cbd66f812f1bc2ab30bc4b1e4b51ed5773"
-
-"@sonarwhal/rule-highest-available-document-mode@^3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-highest-available-document-mode/-/rule-highest-available-document-mode-3.0.4.tgz#a37f692f1b3221ae8cae4f064e35e1930d0cf327"
-
-"@sonarwhal/rule-html-checker@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-html-checker/-/rule-html-checker-4.0.0.tgz#125f80678da52a59234516f0bb157611238c1dba"
-  dependencies:
-    html-validator "^3.0.0"
-    lodash.uniqby "^4.7.0"
-
-"@sonarwhal/rule-http-cache@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-http-cache/-/rule-http-cache-3.1.2.tgz#29a91f28b58d35720096026dd9c727cefa6f4f1a"
-
-"@sonarwhal/rule-http-compression@^4.0.2":
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-http-compression/-/rule-http-compression-4.0.4.tgz#2321ce1494e55503089bd0841840033cee197fe2"
-  dependencies:
-    brotli "^1.3.2"
-
-"@sonarwhal/rule-image-optimization-cloudinary@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-image-optimization-cloudinary/-/rule-image-optimization-cloudinary-3.0.2.tgz#2c7db0eef35a855d0bdfa1dd7ff31531b961baff"
-  dependencies:
-    cloudinary "^1.9.1"
-    fs-extra "^5.0.0"
-    image-size "^0.6.2"
-
-"@sonarwhal/rule-meta-charset-utf-8@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-meta-charset-utf-8/-/rule-meta-charset-utf-8-3.0.3.tgz#22100b6b5743aca587b2157b17208bef38b03042"
-  dependencies:
-    cheerio "^1.0.0-rc.2"
-
-"@sonarwhal/rule-meta-viewport@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-meta-viewport/-/rule-meta-viewport-3.0.2.tgz#23dcf794750897e0c50a36a11d4fbb420ef1c69a"
-  dependencies:
-    metaviewport-parser "^0.2.0"
-
-"@sonarwhal/rule-no-bom@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-no-bom/-/rule-no-bom-2.0.5.tgz#ecf6e57be2b796c13f1e140a522e27df57691f56"
-
-"@sonarwhal/rule-no-disallowed-headers@^3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-no-disallowed-headers/-/rule-no-disallowed-headers-3.0.4.tgz#f070b979fc126a3c300c92f8628067256406b1c2"
-
-"@sonarwhal/rule-no-friendly-error-pages@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-no-friendly-error-pages/-/rule-no-friendly-error-pages-3.0.2.tgz#bdaba8fb66286b31d8c62f0acd35afcf1eddd905"
-
-"@sonarwhal/rule-no-html-only-headers@^3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-no-html-only-headers/-/rule-no-html-only-headers-3.0.5.tgz#777a61dfadb35a45fb8444d1893356423dfbed9a"
-
-"@sonarwhal/rule-no-http-redirects@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-no-http-redirects/-/rule-no-http-redirects-3.0.3.tgz#faf5f226a5601b27c5a4815f28ce73bdcc6126a6"
-
-"@sonarwhal/rule-no-protocol-relative-urls@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-no-protocol-relative-urls/-/rule-no-protocol-relative-urls-3.0.2.tgz#419dc3954de8a7accd7640dd7c9274984eadf930"
-
-"@sonarwhal/rule-no-vulnerable-javascript-libraries@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-no-vulnerable-javascript-libraries/-/rule-no-vulnerable-javascript-libraries-3.3.0.tgz#e6e1fb9efbe131374d34847ca53a1cbed7ae2629"
-  dependencies:
-    js-library-detector "^4.3.1"
-    lodash.groupby "^4.6.0"
-    pluralize "^7.0.0"
-    semver "^5.5.0"
-
-"@sonarwhal/rule-sri@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-sri/-/rule-sri-1.0.6.tgz#0a8f21a9cb381acc157cfd2bc69fb06a70a193eb"
-  dependencies:
-    async "^2.6.0"
-
-"@sonarwhal/rule-ssllabs@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-ssllabs/-/rule-ssllabs-3.0.3.tgz#37d8d2073cccf341a88ed03a7998b1f5d8b7ff3b"
-  dependencies:
-    node-ssllabs "^0.5.0"
-
-"@sonarwhal/rule-strict-transport-security@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-strict-transport-security/-/rule-strict-transport-security-3.0.2.tgz#283a12d34fe26082c3ad82ddef030c82a72d6e9f"
-
-"@sonarwhal/rule-stylesheet-limits@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-stylesheet-limits/-/rule-stylesheet-limits-1.0.0.tgz#351b0d9d1ad6a17d46af6c0d300df48274364043"
-
-"@sonarwhal/rule-validate-set-cookie-header@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-validate-set-cookie-header/-/rule-validate-set-cookie-header-3.0.2.tgz#a99f062668d075ad5052f51f561cd83a2c39d2fe"
-
-"@sonarwhal/rule-x-content-type-options@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@sonarwhal/rule-x-content-type-options/-/rule-x-content-type-options-3.0.3.tgz#a97ff12874c5d6493b88d7460c0903e22c1eb8fe"
 
 "@types/babel-types@*", "@types/babel-types@^7.0.0":
   version "7.0.4"
@@ -656,6 +683,10 @@ abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
 
+abab@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -709,7 +740,7 @@ acorn@^4.0.4, acorn@~4.0.2:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.0.3, acorn@^5.3.0, acorn@^5.5.0, acorn@^5.6.0, acorn@^5.6.2:
+acorn@^5.0.0, acorn@^5.0.3, acorn@^5.5.0, acorn@^5.5.3, acorn@^5.6.0, acorn@^5.6.2:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
@@ -763,7 +794,7 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0:
+ajv@^5.1.0, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -866,6 +897,14 @@ anymatch@^2.0.0:
 app-root-path@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.1.0.tgz#98bf6599327ecea199309866e8140368fd2e646a"
+
+applicationinsights@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.3.tgz#ddbf503612cbbfd7c28e087894dd28cfb06450a1"
+  dependencies:
+    diagnostic-channel "0.2.0"
+    diagnostic-channel-publishers "0.2.1"
+    zone.js "0.7.6"
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
@@ -1130,6 +1169,10 @@ aws-sign2@~0.7.0:
 aws4@^1.2.1, aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
+
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
 axe-core@^3.0.2:
   version "3.0.3"
@@ -1978,19 +2021,20 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^2.0.0:
-  version "2.11.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
-  dependencies:
-    caniuse-lite "^1.0.30000792"
-    electron-to-chromium "^1.3.30"
-
-browserslist@^3.2.6, browserslist@^3.2.8:
+browserslist@^3.2.6:
   version "3.2.8"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
   dependencies:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
+
+browserslist@^4.0.0, browserslist@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.0.2.tgz#294388f5844bb3ab15ef7394ca17f49bf7a4e6f1"
+  dependencies:
+    caniuse-lite "^1.0.30000876"
+    electron-to-chromium "^1.3.57"
+    node-releases "^1.0.0-alpha.11"
 
 bs-recipes@1.3.4:
   version "1.3.4"
@@ -2177,18 +2221,22 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-caniuse-api@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-2.0.0.tgz#b1ddb5a5966b16f48dc4998444d4bbc6c7d9d834"
+caniuse-api@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
   dependencies:
-    browserslist "^2.0.0"
+    browserslist "^4.0.0"
     caniuse-lite "^1.0.0"
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000844:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844:
   version "1.0.30000862"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000862.tgz#7ca14f5079fa8f77ac814fca92d45deb4b7eff9d"
+
+caniuse-lite@^1.0.30000876:
+  version "1.0.30000877"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000877.tgz#f189673b86ecc06436520e3e391de6a13ca923b4"
 
 canvas-prebuilt@^1.6.5-prerelease.1:
   version "1.6.5-prerelease.1"
@@ -2267,10 +2315,6 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
-chardet@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.5.0.tgz#fe3ac73c00c3d865ffcc02a0682e2c20b6a06029"
-
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -2301,7 +2345,7 @@ chokidar@1.7.0, chokidar@^1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chokidar@^2.0.2, chokidar@^2.0.3:
+chokidar@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   dependencies:
@@ -2337,12 +2381,12 @@ chrome-launcher@^0.10.2:
     mkdirp "0.5.1"
     rimraf "^2.6.1"
 
-chrome-remote-interface@^0.25.6:
-  version "0.25.7"
-  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.25.7.tgz#827e85fbef3cc561a9ef2404eb7eee355968c5bc"
+chrome-remote-interface@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.26.1.tgz#6c7d4479742b6d236752d716a9bc2d322d7d8ad2"
   dependencies:
     commander "2.11.x"
-    ws "3.3.x"
+    ws "^3.3.3"
 
 chrome-trace-event@^1.0.0:
   version "1.0.0"
@@ -2544,7 +2588,7 @@ colors@^1.1.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.0.tgz#5f20c9fef6945cb1134260aab33bfbdc8295e04e"
 
-combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
+combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5, combined-stream@~1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
@@ -3006,9 +3050,9 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
 
-"cssstyle@>= 0.3.1 < 0.4.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.3.1.tgz#6da9b4cff1bc5d716e6e5fe8e04fcb1b50a49adf"
+cssstyle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.0.0.tgz#79b16d51ec5591faec60e688891f15d2a5705129"
   dependencies:
     cssom "0.3.x"
 
@@ -3261,6 +3305,16 @@ dev-ip@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dev-ip/-/dev-ip-1.0.1.tgz#a76a3ed1855be7a012bb8ac16cb80f3c00dc28f0"
 
+diagnostic-channel-publishers@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz#8e2d607a8b6d79fe880b548bc58cc6beb288c4f3"
+
+diagnostic-channel@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz#cc99af9612c23fb1fff13612c72f2cbfaa8d5a17"
+  dependencies:
+    semver "^5.3.0"
+
 didyoumean@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.1.tgz#e92edfdada6537d484d73c0172fd1eba0c4976ff"
@@ -3327,7 +3381,7 @@ domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
 
-domexception@^1.0.0:
+domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   dependencies:
@@ -3412,22 +3466,21 @@ ecdsa-sig-formatter@1.0.10:
   dependencies:
     safe-buffer "^5.0.1"
 
-edge-diagnostics-adapter@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/edge-diagnostics-adapter/-/edge-diagnostics-adapter-0.6.0.tgz#8901e3b48df2563c6007bc270aef5c40cc03cd84"
-  dependencies:
-    node-pre-gyp "^0.6.38"
-    regedit "^2.2.7"
-    ws "3.2.0"
-    yargs "^9.0.1"
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
+ejs@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
+
+electron-to-chromium@^1.3.47:
   version "1.3.51"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.51.tgz#6a42b49daaf7f22a5b37b991daf949f34dbdb9b5"
+
+electron-to-chromium@^1.3.57:
+  version "1.3.58"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.58.tgz#8267a4000014e93986d9d18c65a8b4022ca75188"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -3654,9 +3707,9 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escodegen@^1.9.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.10.0.tgz#f647395de22519fbd0d928ffcf1d17e0dec2603e"
+escodegen@^1.9.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
   dependencies:
     esprima "^3.1.3"
     estraverse "^4.2.0"
@@ -4107,6 +4160,10 @@ extend@^3.0.0, extend@^3.0.1, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+
 external-editor@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"
@@ -4121,14 +4178,6 @@ external-editor@^2.0.1, external-editor@^2.0.4, external-editor@^2.1.0:
   dependencies:
     chardet "^0.4.0"
     iconv-lite "^0.4.17"
-    tmp "^0.0.33"
-
-external-editor@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.0.tgz#dc35c48c6f98a30ca27a20e9687d7f3c77704bb6"
-  dependencies:
-    chardet "^0.5.0"
-    iconv-lite "^0.4.22"
     tmp "^0.0.33"
 
 extglob@^0.3.1:
@@ -4205,6 +4254,10 @@ figgy-pudding@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.1.0.tgz#a77ed2284175976c424b390b298569e9df86dd1e"
 
+figgy-pudding@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.2.1.tgz#946bdc2515abad5190027113778595462b668eb3"
+
 figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -4225,9 +4278,9 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-type@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-8.0.0.tgz#6e4bccc741187f4113334a4e4a4ef84d54d7cc1e"
+file-type@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-9.0.0.tgz#a68d5ad07f486414dfb2c8866f73161946714a18"
 
 file-url@^2.0.2:
   version "2.0.2"
@@ -4440,7 +4493,7 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-form-data@~2.3.1:
+form-data@~2.3.1, form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
@@ -4520,17 +4573,17 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
-fs-extra@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+fs-extra@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^6.0.0, fs-extra@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
+fs-extra@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -5099,6 +5152,13 @@ har-validator@~5.0.3:
     ajv "^5.1.0"
     har-schema "^2.0.0"
 
+har-validator@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
+  dependencies:
+    ajv "^5.3.0"
+    har-schema "^2.0.0"
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -5220,6 +5280,39 @@ he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+hint@^3.0.0, hint@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/hint/-/hint-3.2.0.tgz#acafdf9a1ad4dc907b16001cd858c2df6a28dc4a"
+  dependencies:
+    ajv "^6.5.1"
+    applicationinsights "^1.0.3"
+    async "^2.6.1"
+    boxen "^1.3.0"
+    browserslist "^4.0.2"
+    caniuse-api "^3.0.0"
+    chalk "^2.4.1"
+    content-type "^1.0.4"
+    debug "^3.1.0"
+    eventemitter2 "^5.0.1"
+    file-type "^9.0.0"
+    file-url "^2.0.2"
+    globby "^8.0.1"
+    handlebars "^4.0.11"
+    is-ci "^1.1.0"
+    is-svg "^3.0.0"
+    lodash "^4.17.10"
+    mime-db "^1.35.0"
+    npm-registry-fetch "^3.2.0"
+    optionator "^0.8.2"
+    ora "^3.0.0"
+    request "^2.88.0"
+    semver "^5.5.0"
+    strip-bom "^3.0.0"
+    strip-json-comments "^2.0.1"
+    update-notifier "^2.5.0"
+  optionalDependencies:
+    "@hint/configuration-web-recommended" "^1.1.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -5270,13 +5363,6 @@ html-encoding-sniffer@^1.0.2:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
-
-html-validator@^3.0.0:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/html-validator/-/html-validator-3.0.5.tgz#c2a67bbeb9c3a68ea7ef1ab01b8b8042f2437d27"
-  dependencies:
-    request "2.87.0"
-    valid-url "1.0.9"
 
 htmlparser2@^3.9.1:
   version "3.9.2"
@@ -5385,7 +5471,7 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.21, iconv-lite@^0.4.22, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.23, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
@@ -5394,10 +5480,6 @@ iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.21, iconv-lite@^0.4.22, i
 ieee754@^1.1.11, ieee754@^1.1.4:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
-
-if-async@^3.7.4:
-  version "3.7.4"
-  resolved "https://registry.yarnpkg.com/if-async/-/if-async-3.7.4.tgz#55868deb0093d3c67bf7166e745353fb9bcb21a2"
 
 iferr@^0.1.5:
   version "0.1.5"
@@ -5413,17 +5495,16 @@ ignore@^3.2.0, ignore@^3.3.3, ignore@^3.3.5, ignore@^3.3.7:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
-iltorb@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/iltorb/-/iltorb-2.3.2.tgz#886b6b406fde6dc5116d8fe431df582328d937a6"
+iltorb@^2.3.2:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/iltorb/-/iltorb-2.4.0.tgz#befef47a5aea0cee46767731cb63859b57e58327"
   dependencies:
     detect-libc "^1.0.3"
-    nan "^2.10.0"
     npmlog "^4.1.2"
-    prebuild-install "^3.0.0"
+    prebuild-install "^5.0.0"
     which-pm-runs "^1.0.0"
 
-image-size@^0.6.2:
+image-size@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.3.tgz#e7e5c65bb534bd7cdcedd6cb5166272a85f75fb2"
 
@@ -5580,24 +5661,6 @@ inquirer@^5.2.0:
     mute-stream "0.0.7"
     run-async "^2.2.0"
     rxjs "^5.5.2"
-    string-width "^2.1.0"
-    strip-ansi "^4.0.0"
-    through "^2.3.6"
-
-inquirer@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.0.0.tgz#e8c20303ddc15bbfc2c12a6213710ccd9e1413d8"
-  dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.0"
-    figures "^2.0.0"
-    lodash "^4.3.0"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rxjs "^6.1.0"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -6045,9 +6108,9 @@ js-base64@^2.1.8:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.5.tgz#e293cd3c7c82f070d700fc7a1ca0a2e69f101f92"
 
-js-library-detector@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-4.3.1.tgz#6d34f55002813bc0a7543deef53faa4e2e79767b"
+js-library-detector@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-5.0.0.tgz#ceed3346aabe31de705249eba807d7a4a93cf280"
 
 js-stringify@^1.0.1:
   version "1.0.2"
@@ -6068,35 +6131,35 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@^11.11.0:
-  version "11.11.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.11.0.tgz#df486efad41aee96c59ad7a190e2449c7eb1110e"
+jsdom@^11.12.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
   dependencies:
-    abab "^1.0.4"
-    acorn "^5.3.0"
+    abab "^2.0.0"
+    acorn "^5.5.3"
     acorn-globals "^4.1.0"
     array-equal "^1.0.0"
     cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.3.1 < 0.4.0"
+    cssstyle "^1.0.0"
     data-urls "^1.0.0"
-    domexception "^1.0.0"
-    escodegen "^1.9.0"
+    domexception "^1.0.1"
+    escodegen "^1.9.1"
     html-encoding-sniffer "^1.0.2"
-    left-pad "^1.2.0"
-    nwsapi "^2.0.0"
+    left-pad "^1.3.0"
+    nwsapi "^2.0.7"
     parse5 "4.0.0"
     pn "^1.1.0"
-    request "^2.83.0"
+    request "^2.87.0"
     request-promise-native "^1.0.5"
     sax "^1.2.4"
     symbol-tree "^3.2.2"
-    tough-cookie "^2.3.3"
+    tough-cookie "^2.3.4"
     w3c-hr-time "^1.0.1"
     webidl-conversions "^4.0.2"
     whatwg-encoding "^1.0.3"
     whatwg-mimetype "^2.1.0"
     whatwg-url "^6.4.1"
-    ws "^4.0.0"
+    ws "^5.2.0"
     xml-name-validator "^3.0.0"
 
 jsesc@^1.3.0:
@@ -6316,7 +6379,7 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-left-pad@^1.2.0:
+left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
@@ -6504,18 +6567,6 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
-lodash.defaultto@^4.14.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaultto/-/lodash.defaultto-4.14.0.tgz#38bd3d425acee733e0e2bbbd4e4b29711cc2ee11"
-
-lodash.foreach@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
-
-lodash.groupby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
-
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -6605,10 +6656,6 @@ lodash.toarray@^4.4.0:
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-
-lodash.uniqby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
 
 lodash.values@^2.4.1:
   version "2.4.1"
@@ -6701,7 +6748,7 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
-make-fetch-happen@^4.0.0:
+make-fetch-happen@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz#141497cb878f243ba93136c83d8aba12c216c083"
   dependencies:
@@ -6934,9 +6981,13 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-"mime-db@>= 1.34.0 < 2", mime-db@^1.34.0:
+"mime-db@>= 1.34.0 < 2":
   version "1.34.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.34.0.tgz#452d0ecff5c30346a6dc1e64b1eaee0d3719ff9a"
+
+mime-db@^1.35.0, mime-db@~1.35.0:
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
 
 mime-db@~1.33.0:
   version "1.33.0"
@@ -6947,6 +6998,12 @@ mime-types@^2.0.8, mime-types@^2.1.12, mime-types@^2.1.16, mime-types@~2.1.17, m
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime-types@~2.1.19:
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
+  dependencies:
+    mime-db "~1.35.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -7097,6 +7154,10 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
 
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 morgan@^1.8.2:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.0.tgz#d01fa6c65859b76fcf31b3cb53a3821a311d8051"
@@ -7191,6 +7252,14 @@ ncp@1.0.x:
 needle@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
+needle@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.2.tgz#1120ca4c41f2fcc6976fd28a8968afe239929418"
   dependencies:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
@@ -7317,7 +7386,22 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pre-gyp@^0.6.29, node-pre-gyp@^0.6.38:
+node-pre-gyp@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
+
+node-pre-gyp@^0.6.29:
   version "0.6.39"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
   dependencies:
@@ -7332,6 +7416,12 @@ node-pre-gyp@^0.6.29, node-pre-gyp@^0.6.38:
     semver "^5.3.0"
     tar "^2.2.1"
     tar-pack "^3.4.0"
+
+node-releases@^1.0.0-alpha.11:
+  version "1.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.0.0-alpha.11.tgz#73c810acc2e5b741a17ddfbb39dfca9ab9359d8a"
+  dependencies:
+    semver "^5.3.0"
 
 node-sass@4.9.1:
   version "4.9.1"
@@ -7392,13 +7482,6 @@ node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
 
-node-windows@^0.1.14:
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/node-windows/-/node-windows-0.1.14.tgz#31bb0503da3bc637f2bfaa8b266640a2e92d891f"
-  dependencies:
-    optimist "~0.6.0"
-    xml "0.0.12"
-
 nodesecurity-npm-utils@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/nodesecurity-npm-utils/-/nodesecurity-npm-utils-6.0.0.tgz#5fb5974008c0c97a5c01844faa8fd3fc5520806c"
@@ -7455,7 +7538,7 @@ npm-bundled@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
 
-npm-package-arg@^6.0.0:
+npm-package-arg@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-6.1.0.tgz#15ae1e2758a5027efb4c250554b85a737db7fcc1"
   dependencies:
@@ -7477,15 +7560,15 @@ npm-path@^2.0.2:
   dependencies:
     which "^1.2.10"
 
-npm-registry-fetch@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-3.1.1.tgz#e96bae698afdd45d4a01aca29e881fc0bc55206c"
+npm-registry-fetch@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-3.2.0.tgz#94ec859c4dd395f924e575cee471da6fd3906d53"
   dependencies:
     bluebird "^3.5.1"
-    figgy-pudding "^3.1.0"
-    lru-cache "^4.1.2"
-    make-fetch-happen "^4.0.0"
-    npm-package-arg "^6.0.0"
+    figgy-pudding "^3.2.0"
+    lru-cache "^4.1.3"
+    make-fetch-happen "^4.0.1"
+    npm-package-arg "^6.1.0"
 
 npm-run-all@4.1.3:
   version "4.1.3"
@@ -7548,13 +7631,17 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nwsapi@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.4.tgz#dc79040a5f77b97716dc79565fc7fc3ef7d50570"
+nwsapi@^2.0.7:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.8.tgz#e3603579b7e162b3dbedae4fb24e46f771d8fa24"
 
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
 object-assign@^3.0.0:
   version "3.0.0"
@@ -7657,7 +7744,7 @@ opn@^5.3.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optimist@^0.6.1, optimist@~0.6.0:
+optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   dependencies:
@@ -7684,9 +7771,9 @@ ora@0.2.3, ora@^0.2.3:
     cli-spinners "^0.1.2"
     object-assign "^4.0.1"
 
-ora@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-2.1.0.tgz#6caf2830eb924941861ec53a173799e008b51e5b"
+ora@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.0.0.tgz#8179e3525b9aafd99242d63cc206fd64732741d0"
   dependencies:
     chalk "^2.3.1"
     cli-cursor "^2.1.0"
@@ -8117,9 +8204,9 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
-prebuild-install@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-3.0.0.tgz#0fd5b2c48ffcf4ceefa64d04a4c5a328d79ad66c"
+prebuild-install@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.0.0.tgz#bc1a24636beaf0af7945c0a84d4b9249bf191b6b"
   dependencies:
     detect-libc "^1.0.3"
     expand-template "^1.0.2"
@@ -8131,7 +8218,7 @@ prebuild-install@^3.0.0:
     npmlog "^4.0.1"
     os-homedir "^1.0.1"
     pump "^2.0.1"
-    rc "^1.1.6"
+    rc "^1.2.7"
     simple-get "^2.7.0"
     tar-fs "^1.13.0"
     tunnel-agent "^0.6.0"
@@ -8439,7 +8526,7 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-qs@~6.5.1:
+qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -8599,15 +8686,6 @@ read@1.0.x:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@>=1.0.33-1 <1.1.0-0":
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
 readable-stream@~2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
@@ -8667,15 +8745,6 @@ redeyed@~1.0.0:
   resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-1.0.1.tgz#e96c193b40c0816b00aec842698e61185e55498a"
   dependencies:
     esprima "~3.0.0"
-
-regedit@^2.2.7:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/regedit/-/regedit-2.2.7.tgz#47028487a471aaa7d62a8d0383cceeedebf3af80"
-  dependencies:
-    debug "^2.1.1"
-    if-async "^3.7.4"
-    stream-slicer "0.0.6"
-    through2 "^0.6.3"
 
 regenerate@^1.2.1:
   version "1.4.0"
@@ -8881,6 +8950,31 @@ request@2.87.0, request@^2.58.0, request@^2.72.0, request@^2.74.0, request@^2.79
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
+
+request@^2.88.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 request@~2.79.0:
   version "2.79.0"
@@ -9362,14 +9456,6 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shelljs@^0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -9537,54 +9623,6 @@ socks@~2.2.0:
   dependencies:
     ip "^1.1.5"
     smart-buffer "^4.0.1"
-
-sonarwhal@1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/sonarwhal/-/sonarwhal-1.11.2.tgz#bc93138238e5fcbc97f6ed1d9c62d365b05bdf51"
-  dependencies:
-    "@sonarwhal/configuration-web-recommended" "^6.1.0"
-    ajv "^6.5.1"
-    async "^2.6.1"
-    boxen "^1.3.0"
-    browserslist "^3.2.8"
-    caniuse-api "^2.0.0"
-    canvas-prebuilt "^1.6.5-prerelease.1"
-    chalk "^2.4.1"
-    chokidar "^2.0.3"
-    chrome-launcher "^0.10.2"
-    chrome-remote-interface "^0.25.6"
-    content-type "^1.0.4"
-    debug "^3.1.0"
-    eventemitter2 "^5.0.1"
-    file-type "^8.0.0"
-    file-url "^2.0.2"
-    fs-extra "^6.0.1"
-    globby "^8.0.1"
-    handlebars "^4.0.11"
-    iconv-lite "^0.4.21"
-    iltorb "^2.3.0"
-    inquirer "^6.0.0"
-    is-ci "^1.1.0"
-    is-svg "^3.0.0"
-    jsdom "^11.11.0"
-    lockfile "^1.0.4"
-    lodash "^4.17.10"
-    log-symbols "^2.2.0"
-    mime-db "^1.34.0"
-    mkdirp "^0.5.1"
-    npm-registry-fetch "^3.1.1"
-    optionator "^0.8.2"
-    ora "^2.0.0"
-    request "^2.87.0"
-    require-uncached "^1.0.3"
-    semver "^5.5.0"
-    shelljs "^0.8.1"
-    strip-bom "^3.0.0"
-    strip-json-comments "^2.0.1"
-    text-table "^0.2.0"
-    update-notifier "^2.5.0"
-  optionalDependencies:
-    "@sonarwhal/connector-edge" "^1.0.0"
 
 sort-keys@^2.0.0:
   version "2.0.0"
@@ -9827,10 +9865,6 @@ stream-http@^2.7.2:
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
-
-stream-slicer@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/stream-slicer/-/stream-slicer-0.0.6.tgz#f86b2ac5c2440b7a0a87b71f33665c0788046138"
 
 stream-throttle@^0.1.3:
   version "0.1.3"
@@ -10135,13 +10169,6 @@ through2@2.0.1:
     readable-stream "~2.0.0"
     xtend "~4.0.0"
 
-through2@^0.6.3:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
-  dependencies:
-    readable-stream ">=1.0.33-1 <1.1.0-0"
-    xtend ">=4.0.0 <4.1.0-0"
-
 through2@^2.0.0, through2@^2.0.2, through2@^2.0.3, through2@~2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
@@ -10243,7 +10270,7 @@ toml@^2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/toml/-/toml-2.3.3.tgz#8d683d729577cb286231dfc7a8affe58d31728fb"
 
-tough-cookie@>=2.3.3, tough-cookie@^2.3.3:
+tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
   dependencies:
@@ -10621,7 +10648,7 @@ uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
@@ -10631,7 +10658,7 @@ v8flags@^2.1.1:
   dependencies:
     user-home "^1.1.1"
 
-valid-url@1.0.9, valid-url@^1:
+valid-url@^1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
 
@@ -10934,15 +10961,7 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.2.0.tgz#d5d3d6b11aff71e73f808f40cc69d52bb6d4a185"
-  dependencies:
-    async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
-    ultron "~1.1.0"
-
-ws@3.3.x, ws@~3.3.1:
+ws@^3.3.3, ws@~3.3.1:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
   dependencies:
@@ -10950,12 +10969,11 @@ ws@3.3.x, ws@~3.3.1:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-ws@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-4.1.0.tgz#a979b5d7d4da68bf54efe0408967c324869a7289"
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   dependencies:
     async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
 
 xdg-basedir@^2.0.0:
   version "2.0.0"
@@ -10971,15 +10989,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
-xml@0.0.12:
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/xml/-/xml-0.0.12.tgz#f08b347109912be00285785f46f15ad8e50a5f67"
-
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
 
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
@@ -11192,3 +11206,7 @@ zip-stream@^1.2.0:
     compress-commons "^1.2.0"
     lodash "^4.8.0"
     readable-stream "^2.0.0"
+
+zone.js@0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.7.6.tgz#fbbc39d3e0261d0986f1ba06306eb3aeb0d22009"


### PR DESCRIPTION
sonarwhal was renamed to webhint. This PR updates all references
to the old package.

Ref: https://medium.com/webhint/webhint-a-hinting-engine-for-the-web-ef0d3fa32ea9